### PR TITLE
Updating the compilation instruction

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 1. Build the cache simulator.
- % cc -lm -o cachesim cache.c
+ % cc -o cachesim cache.c -lm
 
 2. Test the cache simulator.
  % gunzip -c traces/art.trace.gz | ./cachesim


### PR DESCRIPTION
We need to put the -lm at the end in order to make it compiles on Ubuntu.